### PR TITLE
Allow to pass feed encoding at build.

### DIFF
--- a/lib/gtfs/model.rb
+++ b/lib/gtfs/model.rb
@@ -77,8 +77,8 @@ module GTFS
         self.define_singleton_method(:filename) {filename}
       end
 
-      def each(filename)
-        CSV.foreach(filename, :headers => true) do |row|
+      def each(filename, options)
+        CSV.foreach(filename, :headers => true, :encoding => options[:encoding]) do |row|
           yield parse_model(row.to_hash)
         end
       end

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -13,7 +13,7 @@ module GTFS
     OPTIONAL_SOURCE_FILES = ENTITIES.reject(&:required_file?).map(&:filename)
     SOURCE_FILES = ENTITIES.map(&:filename)
 
-    DEFAULT_OPTIONS = {strict: true}
+    DEFAULT_OPTIONS = {strict: true, encoding: "utf-8"}
 
     attr_accessor :source, :archive, :options
 
@@ -64,13 +64,13 @@ module GTFS
 
     ENTITIES.each do |entity|
       define_method entity.name.to_sym do
-        parse_file entity.filename do |f|
+        parse_file entity.filename, options do |f|
           entity.send("parse_#{entity.name}".to_sym, f.read, options)
         end
       end
 
       define_method "each_#{entity.singular_name}".to_sym do |&block|
-        entity.each(File.join(@tmp_dir, entity.filename)) { |model| block.call model }
+        entity.each(File.join(@tmp_dir, entity.filename), options) { |model| block.call model }
       end
     end
 
@@ -78,9 +78,9 @@ module GTFS
       @files ||= {}
     end
 
-    def parse_file(filename)
+    def parse_file(filename, options)
       raise_if_missing_source filename
-      open File.join(@tmp_dir, '/', filename), 'r:bom|utf-8' do |f|
+      open File.join(@tmp_dir, '/', filename), "r:#{options[:encoding]}" do |f|
         files[filename] ||= yield f
       end
     end

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -39,7 +39,7 @@ describe GTFS::Source do
     context 'with options to disable strict checks' do
       let(:opts) {{strict: false}}
 
-      its(:options) {should == {strict: false}}
+      its(:options) {should == GTFS::Source::DEFAULT_OPTIONS.merge({strict: false})}
     end
   end
 


### PR DESCRIPTION
Hi,

I think it would more flexible to allow lib users to pass the feed encoding to build.

I got issue with each_XXX methods with utf8 with BOM encoding.

Cheers